### PR TITLE
`.rubocop-rspec` config file

### DIFF
--- a/config/.rubocop-rspec.yml
+++ b/config/.rubocop-rspec.yml
@@ -1,0 +1,8 @@
+Hooks:
+  - prepend_before
+  - before
+  - append_before
+  - around
+  - prepend_after
+  - after
+  - append_after

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,14 @@
 ---
+rspec_language:
+  Hooks:
+  - prepend_before
+  - before
+  - append_before
+  - around
+  - prepend_after
+  - after
+  - append_after
+
 AllCops:
   RSpec:
     Patterns:

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,14 +1,4 @@
 ---
-rspec_language:
-  Hooks:
-  - prepend_before
-  - before
-  - append_before
-  - around
-  - prepend_after
-  - after
-  - append_after
-
 AllCops:
   RSpec:
     Patterns:

--- a/lib/rubocop/rspec.rb
+++ b/lib/rubocop/rspec.rb
@@ -7,11 +7,20 @@ module RuboCop
     CONFIG_DEFAULT   = GEM_ROOT.join('config', 'default.yml').freeze
     CONFIG           = YAML.safe_load(CONFIG_DEFAULT.read).freeze
     PROJECT_ROOT     = (defined?(Bundler) ? Bundler.root : Dir.pwd).freeze
-    ROOT_CONFIG_FILE = File.join(PROJECT_ROOT, '.rubocop.yml').freeze
-    ROOT_CONFIG      = YAML.safe_load(File.read(ROOT_CONFIG_FILE)).freeze
+    RSPEC_CONFIG_FILE = File.join(PROJECT_ROOT, '.rubocop-rspec.yml').freeze
+
+    # Create default rspec config in project root if absent
+    unless File.exists?(RSPEC_CONFIG_FILE)
+      FileUtils.cp(
+        GEM_ROOT.join('config', '.rubocop-rspec.yml'),
+        RSPEC_CONFIG_FILE
+      )
+    end
+
+    RSPEC_CONFIG = YAML.safe_load(File.read(RSPEC_CONFIG_FILE)).freeze
 
     private_constant(
-      :CONFIG_DEFAULT, :GEM_ROOT, :PROJECT_ROOT, :ROOT_CONFIG_FILE
+      :CONFIG_DEFAULT, :GEM_ROOT, :PROJECT_ROOT, :RSPEC_CONFIG_FILE
     )
   end
 end

--- a/lib/rubocop/rspec.rb
+++ b/lib/rubocop/rspec.rb
@@ -3,10 +3,15 @@
 module RuboCop
   # RuboCop RSpec project namespace
   module RSpec
-    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
-    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
-    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+    GEM_ROOT         = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT   = GEM_ROOT.join('config', 'default.yml').freeze
+    CONFIG           = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+    PROJECT_ROOT     = (defined?(Bundler) ? Bundler.root : Dir.pwd).freeze
+    ROOT_CONFIG_FILE = File.join(PROJECT_ROOT, '.rubocop.yml').freeze
+    ROOT_CONFIG      = YAML.safe_load(File.read(ROOT_CONFIG_FILE)).freeze
 
-    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+    private_constant(
+      :CONFIG_DEFAULT, :GEM_ROOT, :PROJECT_ROOT, :ROOT_CONFIG_FILE
+    )
   end
 end

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -53,6 +53,15 @@ module RuboCop
         attr_reader :selectors
       end
 
+      # Resolver of RSpec DSL configuration
+      module LanguageConfig
+        def self.for(*sections)
+          [CONFIG, ROOT_CONFIG].map do |hash|
+            hash&.dig('rspec_language', *sections) || []
+          end.flatten.map(&:to_sym)
+        end
+      end
+
       module ExampleGroups
         GROUPS  = SelectorSet.new(%i[describe context feature example_group])
         SKIPPED = SelectorSet.new(%i[xdescribe xcontext xfeature])
@@ -91,17 +100,7 @@ module RuboCop
       end
 
       module Hooks
-        ALL = SelectorSet.new(
-          %i[
-            prepend_before
-            before
-            append_before
-            around
-            prepend_after
-            after
-            append_after
-          ]
-        )
+        ALL = SelectorSet.new(LanguageConfig.for('Hooks'))
 
         module Scopes
           ALL = SelectorSet.new(

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -56,9 +56,7 @@ module RuboCop
       # Resolver of RSpec DSL configuration
       module LanguageConfig
         def self.for(*sections)
-          [CONFIG, ROOT_CONFIG].map do |hash|
-            hash&.dig('rspec_language', *sections) || []
-          end.flatten.map(&:to_sym)
+          (RSPEC_CONFIG.dig(*sections) || []).map(&:to_sym)
         end
       end
 

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:config_keys) do
-    cop_names + %w[AllCops]
+    cop_names + %w[AllCops rspec_language]
   end
 
   def cop_configuration(config_key)

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -76,4 +76,29 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       end
     RUBY
   end
+
+  # TODO: These tests just demonstrate that hooks aliases work in rewritten cops
+  it 'does NOT add an offense for `expect` with block in `custom_hook` hook' do
+    expect_no_offenses(<<-RUBY)
+      setup do
+        expect { something }.to eq('foo')
+      end
+    RUBY
+  end
+
+  context 'when `custom_hook` is configured in AllCops.RSpec.Aliases.Hooks',
+          skip: true do
+    # TODO: Find a way to test it dynamically
+    # `custom_hook` even cannot be placed in .rubocop.yml
+    # because it will be treated as unrecognized cop
+
+    it 'adds an offense for `expect` with block in `custom_hook` hook' do
+      expect_offense(<<-RUBY)
+        custom_hook do
+          expect { something }.to eq('foo')
+          ^^^^^^ Do not use `expect` in `custom_hook` hook
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
## `.rubocop-rspec` config file ##

Uses `.rubocop-rspec.yml` to define RSpec DSL. It creates `.rubocop-rspec.yml` filled with defaults on first run now.
Can be reworked to merge with default config instead if it's better to allow user to just extend RSpec DSL, but not redefine.
I personally like explicit version because it's obvious and almost doesn't require any documentation.

Looks like more consistent solution since all the language configuration is placed in separate yaml file and not associated with rubocop configs at all.

## There are some cons still: ##
* It introduces yet another config file
* It doesn't work with caching at all. Some research is needed to be done here if we'll decide to go with this one.